### PR TITLE
Use new github2 client secret.

### DIFF
--- a/kubernetes/zuul/overlays/zuul_ci/configs/zuul.conf.hcl
+++ b/kubernetes/zuul/overlays/zuul_ci/configs/zuul.conf.hcl
@@ -50,7 +50,7 @@ dburi=postgresql://{{ file "/vault/db-secrets/user" }}:{{ file "/vault/db-secret
 [connection "github"]
 name=github
 driver=github
-{{- with secret "secret/zuul/connections/github" }}
+{{- with secret "secret/zuul/connections/github2" }}
 webhook_token={{ .Data.data.webhook_token }}
 app_id={{ .Data.data.app_id }}
 {{- end }}


### PR DESCRIPTION
This should fix [zuul-config/issue#91](https://github.com/SovereignCloudStack/zuul-config/issues/91)